### PR TITLE
APPDESCRIP-25: Update existing application repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ Application descriptor repository for a minimal FOLIO platform installation
 | `folio_stripes-core`             |
 | `folio_notes`                    |
 | `folio_stripes-smart-components` |
+| `folio_authorization-policies`   |
+| `folio_authorization-roles`      |

--- a/app-platform-minimal.template.json
+++ b/app-platform-minimal.template.json
@@ -3,7 +3,7 @@
   "version": "${project.version}",
   "description": "${project.description}",
   "platform": "base",
-  "dependencies": [ ],
+  "dependencies": [],
   "modules": [
     {
       "name": "mod-configuration",
@@ -30,15 +30,15 @@
       "version": "latest"
     },
     {
+      "name": "mod-login-keycloak",
+      "version": "latest"
+    },
+    {
       "name": "mod-users-keycloak",
       "version": "latest"
     },
     {
       "name": "mod-roles-keycloak",
-      "version": "latest"
-    },
-    {
-      "name": "mod-login-keycloak",
       "version": "latest"
     },
     {
@@ -73,6 +73,14 @@
     },
     {
       "name": "folio_stripes-smart-components",
+      "version": "latest"
+    },
+    {
+      "name": "folio_authorization-policies",
+      "version": "latest"
+    },
+    {
+      "name": "folio_authorization-roles",
       "version": "latest"
     }
   ]


### PR DESCRIPTION
### Purpose
- Bring the HEAD/master of these repos up to date (set of modules, application dependencies, application version in pom.xml, etc.).
- See [application-descriptors/Quesnelia at Quesnelia.SP1 · folio-org/application-descriptors](https://github.com/folio-org/application-descriptors/tree/Quesnelia.SP1/Quesnelia) 
- The module versions in the master branch should be “latest” to allow for snapshot versions of the application descriptors to be generated.

[APPDESCRIP-25](https://folio-org.atlassian.net/browse/APPDESCRIP-25)