### PR TITLE
RANCHER-2893. Introduce a validation skip parameter and temporarily disable FAR publishing and artifact building.

### DIFF
--- a/.github/update-config.yml
+++ b/.github/update-config.yml
@@ -29,15 +29,14 @@ branches:
       need_pr: false
       pre_release: "only"
       descriptor_build_offset: "100200000000000"
+      skip_dependency_validation: bypass
       ruleset:
         enabled: false
   - R1-2025-ci:
       enabled: true
       need_pr: true
       preRelease: "false"
+      publish: false #TODO: enable when FSE disables its release pipeline
+      release: false #TODO: enable when FSE disables its release pipeline
       ruleset:
         enabled: true
-#  - R2-2024:
-#      enable: false
-#      need_pr: true
-#      pre_release: "false"

--- a/.github/workflows/update-scheduler.yml
+++ b/.github/workflows/update-scheduler.yml
@@ -67,5 +67,4 @@ jobs:
       skip_interface_validation: ${{ matrix.skip_interface_validation }}
       skip_dependency_validation: ${{ matrix.skip_dependency_validation }}
       publish: ${{ matrix.publish }}
-      release: ${{ matrix.release }}
     secrets: inherit

--- a/.github/workflows/update-scheduler.yml
+++ b/.github/workflows/update-scheduler.yml
@@ -64,4 +64,8 @@ jobs:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
       pr_reviewers: ${{ needs.get-config.outputs.pr_reviewers }}
       pr_labels: ${{ needs.get-config.outputs.pr_labels }}
+      skip_interface_validation: ${{ matrix.skip_interface_validation }}
+      skip_dependency_validation: ${{ matrix.skip_dependency_validation }}
+      publish: ${{ matrix.publish }}
+      release: ${{ matrix.release }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Configures new RANCHER-2893 parameters for app-platform-minimal and updates the scheduler workflow to pass them.

### Changes

**`.github/update-config.yml`**:
- **snapshot branch**: Set `skip_dependency_validation: bypass` — dependency validation runs but failures are treated as warnings instead of blocking the update. This prevents deadlocks during coordinated interface version changes (e.g. `users.settings` 1.0 -> 2.0) while preserving validation visibility. Platform-level hourly check remains the hard gate.
- **R1-2025-ci branch**: Set `publish: false` and `release: false` — temporarily disables FAR publishing and GitHub release creation until FSE disables its release pipeline.
- Removed commented-out R2-2024 branch config.

**`.github/workflows/update-scheduler.yml`**:
- Passes 3 new matrix fields (`skip_interface_validation`, `skip_dependency_validation`, `publish`) to the application-update workflow.

Refs: RANCHER-2893